### PR TITLE
Update guacamole to retrieve connection instead of apps

### DIFF
--- a/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/NoAuthLoggedProvider.java
+++ b/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/NoAuthLoggedProvider.java
@@ -184,7 +184,7 @@ public class NoAuthLoggedProvider extends SimpleAuthenticationProvider {
 
         String token = login();
 
-        URL myUrl = new URL("http://" + hostname + ":" + port + "/api/apps/all");
+        URL myUrl = new URL("http://" + hostname + ":" + port + "/api/apps/connections");
         HttpURLConnection urlConn = (HttpURLConnection)myUrl.openConnection();
 
         urlConn.setInstanceFollowRedirects(false);
@@ -211,18 +211,18 @@ public class NoAuthLoggedProvider extends SimpleAuthenticationProvider {
             JSONObject connection = appList.getJSONObject(i);
             GuacamoleConfiguration config = new GuacamoleConfiguration();
 
-            config.setProtocol("rdp");
-            config.setParameter("hostname", connection.getString("Hostname"));
-            config.setParameter("port", connection.getString("Port"));
-            config.setParameter("username", connection.getString("Username"));
-            config.setParameter("password", connection.getString("Password"));
+            config.setProtocol(connection.getString("protocol"));
+            config.setParameter("hostname", connection.getString("hostname"));
+            config.setParameter("port", connection.getString("port"));
+            config.setParameter("username", connection.getString("username"));
+            config.setParameter("password", connection.getString("password"));
             config.setParameter("security", "nla");
             config.setParameter("ignore-cert", "true");
-            if (!connection.has("RemoteApp")) {
-                config.setParameter("remote-app", connection.getString("RemoteApp"));
+            if (connection.has("remote_app")) {
+                config.setParameter("remote-app", connection.getString("remote_app"));
             }
 
-            configs.put(connection.getString("ConnectionName"), config);
+            configs.put(connection.getString("app_name"), config);
         }
 
         return configs;

--- a/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/user/UserContext.java
+++ b/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/user/UserContext.java
@@ -274,7 +274,7 @@ public class UserContext implements org.glyptodon.guacamole.net.auth.UserContext
 
 		String token = login();
 
-		URL myUrl = new URL("http://" + hostname + ":" + port + "/api/apps/all");
+		URL myUrl = new URL("http://" + hostname + ":" + port + "/api/apps/connections");
 		HttpURLConnection urlConn = (HttpURLConnection)myUrl.openConnection();
 
 		urlConn.setInstanceFollowRedirects(false);
@@ -301,18 +301,18 @@ public class UserContext implements org.glyptodon.guacamole.net.auth.UserContext
 			JSONObject connection = appList.getJSONObject(i);
 			GuacamoleConfiguration config = new GuacamoleConfiguration();
 
-			config.setProtocol("rdp");
-			config.setParameter("hostname", connection.getString("Hostname"));
-			config.setParameter("port", connection.getString("Port"));
-			config.setParameter("username", connection.getString("Username"));
-			config.setParameter("password", connection.getString("Password"));
+			config.setProtocol(connection.getString("protocol"));
+			config.setParameter("hostname", connection.getString("hostname"));
+			config.setParameter("port", connection.getString("port"));
+			config.setParameter("username", connection.getString("username"));
+			config.setParameter("password", connection.getString("password"));
 			config.setParameter("security", "nla");
 			config.setParameter("ignore-cert", "true");
-			if (connection.has("RemoteApp")) {
-				config.setParameter("remote-app", connection.getString("RemoteApp"));
+			if (connection.has("remote_app")) {
+				config.setParameter("remote-app", connection.getString("remote_app"));
 			}
 
-			configs.put(connection.getString("ConnectionName"), config);
+			configs.put(connection.getString("app_name"), config);
 		}
 
 		return configs;


### PR DESCRIPTION
The API now makes a distinction between apps and connection. Guacamole authentication plugin has been adapted to the new values
